### PR TITLE
feat: add the production infrastructure for the statics website

### DIFF
--- a/infra/main.tf
+++ b/infra/main.tf
@@ -1,0 +1,198 @@
+# =============================================================================
+# S3 BUCKET (PRIVATE STORAGE)
+# =============================================================================
+
+resource "aws_s3_bucket" "website" {
+  # Use the provided bucket name or fallback to the domain name
+  bucket = var.bucket_name != null ? var.bucket_name : var.domain_name
+}
+
+# Block ALL public access. We only allow access via CloudFront.
+resource "aws_s3_bucket_public_access_block" "website" {
+  bucket = aws_s3_bucket.website.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# Enable server-side encryption by default (Security Best Practice)
+resource "aws_s3_bucket_server_side_encryption_configuration" "website" {
+  bucket = aws_s3_bucket.website.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+# # Optional: Upload a default index.html for testing
+# resource "aws_s3_object" "index" {
+#   bucket       = aws_s3_bucket.website.id
+#   key          = "index.html"
+#   content      = "<html><body><h1>Deployed via Terraform</h1></body></html>"
+#   content_type = "text/html"
+# }
+
+# =============================================================================
+# SSL CERTIFICATE (ACM)
+# =============================================================================
+
+# Request the certificate in us-east-1 (Required for CloudFront)
+resource "aws_acm_certificate" "cert" {
+  provider          = aws.us_east_1
+  domain_name       = var.domain_name
+  validation_method = "DNS"
+
+  # Support both root and www
+  subject_alternative_names = ["www.${var.domain_name}"]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Get the Route53 Zone ID
+data "aws_route53_zone" "main" {
+  name         = var.domain_name
+  private_zone = false
+}
+
+# Create the DNS records for Certificate Validation
+resource "aws_route53_record" "cert_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.cert.domain_validation_options : dvo.domain_name => dvo
+  }
+
+  allow_overwrite = true
+  name            = each.value.resource_record_name
+  records         = [each.value.resource_record_value]
+  ttl             = 60
+  type            = each.value.resource_record_type
+  zone_id         = data.aws_route53_zone.main.zone_id
+}
+
+# Wait for the certificate to be validated
+resource "aws_acm_certificate_validation" "cert" {
+  provider                = aws.us_east_1
+  certificate_arn         = aws_acm_certificate.cert.arn
+  validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
+}
+
+# =============================================================================
+# CLOUDFRONT DISTRIBUTION (CDN)
+# =============================================================================
+
+# Origin Access Control (OAC) - The modern way to secure S3 origins
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "${var.domain_name}-oac"
+  description                       = "OAC for static website"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "s3_distribution" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+  aliases             = [var.domain_name, "www.${var.domain_name}"]
+  price_class         = "PriceClass_100" # NOTE: If we need global performance, change this to PriceClass_All. Otherwise, use PriceClass_100 (USA/Europe) for lowest cost
+
+  origin {
+    domain_name              = aws_s3_bucket.website.bucket_regional_domain_name
+    origin_id                = "S3-${aws_s3_bucket.website.id}"
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = "S3-${aws_s3_bucket.website.id}"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 86400
+    compress               = true
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate_validation.cert.certificate_arn
+    ssl_support_method       = "sni-only"
+    minimum_protocol_version = "TLSv1.2_2021"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}
+
+# =============================================================================
+# S3 BUCKET POLICY (CONNECT S3 TO CLOUDFRONT)
+# =============================================================================
+
+# Allow CloudFront OAC to read from the bucket
+resource "aws_s3_bucket_policy" "website" {
+  bucket = aws_s3_bucket.website.id
+  policy = data.aws_iam_policy_document.s3_website_policy.json
+}
+
+data "aws_iam_policy_document" "s3_website_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.website.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.s3_distribution.arn]
+    }
+  }
+}
+
+# =============================================================================
+# ROUTE 53 RECORDS (DNS)
+# =============================================================================
+
+# Alias record for the root domain
+resource "aws_route53_record" "root" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+# Alias record for www
+resource "aws_route53_record" "www" {
+  zone_id = data.aws_route53_zone.main.zone_id
+  name    = "www.${var.domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/infra/outputs.tf
+++ b/infra/outputs.tf
@@ -1,0 +1,14 @@
+output "s3_bucket_name" {
+  description = "The name of the S3 bucket where you should upload your files."
+  value       = aws_s3_bucket.website.id
+}
+
+output "cloudfront_domain_name" {
+  description = "The internal CloudFront domain name."
+  value       = aws_cloudfront_distribution.s3_distribution.domain_name
+}
+
+output "website_url" {
+  description = "The full URL of your website."
+  value       = "https://${var.domain_name}"
+}

--- a/infra/providers.tf
+++ b/infra/providers.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Primary Provider (Your default region)
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = var.common_tags
+  }
+}
+
+# Secondary Provider (MANDATORY for ACM Certificates)
+# CloudFront certificates *must* be in us-east-1
+provider "aws" {
+  alias  = "us_east_1"
+  region = "us-east-1"
+
+  default_tags {
+    tags = var.common_tags
+  }
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -1,0 +1,26 @@
+variable "aws_region" {
+  description = "The AWS region to deploy resources (e.g., eu-west-1)."
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "domain_name" {
+  description = "The domain name for the website (e.g., example.com)."
+  type        = string
+}
+
+variable "bucket_name" {
+  description = "The name of the S3 bucket. Must be globally unique. If null, defaults to domain_name."
+  type        = string
+  default     = null
+}
+
+variable "common_tags" {
+  description = "Common tags to apply to all resources."
+  type        = map(string)
+  default = {
+    Project     = "StaticWebsite"
+    Environment = "Production"
+    ManagedBy   = "Terraform"
+  }
+}


### PR DESCRIPTION
### Requirements:
- AWS account
- TF
- Finish WIP

### Infra defined:

1. S3 Bucket (Private): Stores your files. It will block all public access.
2. CloudFront (OAC): We will use Origin Access Control (the modern replacement for OAI). This ensures users can only access your site via CloudFront (HTTPS), not directly via S3.
3. ACM (Free SSL): AWS Certificate Manager provides a free public certificate.
4. Route53: Manages the DNS records.